### PR TITLE
Fix the 'deploymentGroupCreated' output

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,9 @@ This workaround should catch a good share of possible out-of-order deployments. 
 
 * `deploymentId`: AWS CodeDeployment Deployment-ID of the deployment created
 * `deploymentGroupName`: AWS CodeDeployment Deployment Group name used
-* `deploymentGroupCreated`: True, if a new deployment group was created. False, if an existing group was updated.
+* `deploymentGroupCreated`: `1`, if a new deployment group was created; `0` if an existing group was updated.
+
+You can use the expression `if: steps.<your-deployment-step>.outputs.deploymentGroupCreated==true` (or `...==false`) on subsequent workflow steps to run actions only if the deployment created a new deployment group (or updated an existing deployment, respectively).
 
 ## Hacking
 

--- a/create-deployment.js
+++ b/create-deployment.js
@@ -44,7 +44,8 @@ exports.createDeployment = async function(applicationName, fullRepositoryName, b
             }
         }).promise();
         console.log(`⚙️  Updated deployment group '${deploymentGroupName}'`);
-        core.setOutput('deploymentGroupCreated', false);
+
+        core.setOutput('deploymentGroupCreated', 0);
     } catch (e) {
         if (e.code == 'DeploymentGroupDoesNotExistException') {
             await codeDeploy.createDeploymentGroup({
@@ -55,7 +56,8 @@ exports.createDeployment = async function(applicationName, fullRepositoryName, b
                 }
             }).promise();
             console.log(`🎯 Created deployment group '${deploymentGroupName}'`);
-            core.setOutput('deploymentGroupCreated', true);
+
+            core.setOutput('deploymentGroupCreated', 1);
         } else {
             core.setFailed(`🌩  Unhandled exception`);
             throw e;

--- a/dist/index.js
+++ b/dist/index.js
@@ -60,7 +60,8 @@ exports.createDeployment = async function(applicationName, fullRepositoryName, b
             }
         }).promise();
         console.log(`⚙️  Updated deployment group '${deploymentGroupName}'`);
-        core.setOutput('deploymentGroupCreated', false);
+
+        core.setOutput('deploymentGroupCreated', 0);
     } catch (e) {
         if (e.code == 'DeploymentGroupDoesNotExistException') {
             await codeDeploy.createDeploymentGroup({
@@ -71,7 +72,8 @@ exports.createDeployment = async function(applicationName, fullRepositoryName, b
                 }
             }).promise();
             console.log(`🎯 Created deployment group '${deploymentGroupName}'`);
-            core.setOutput('deploymentGroupCreated', true);
+
+            core.setOutput('deploymentGroupCreated', 1);
         } else {
             core.setFailed(`🌩  Unhandled exception`);
             throw e;


### PR DESCRIPTION
Because outputs are passed on through special log outputs, using plain boolean `true` and `false` values does not seem to work. `1` and `0` seem to be cast, however, and work as expected on subsequent step condition.