### PR TITLE
Fix deploy triggered by workflow_dispatch

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -191,7 +191,7 @@ exports.createDeployment = async function(applicationName, fullRepositoryName, b
     const fullRepositoryName = payload.repository.full_name; // like "Codertocat/Hello-World"
 
     const isPullRequest = payload.pull_request !== undefined;
-    const commitId = isPullRequest ? payload.pull_request.head.sha : (payload.head_commit ? payload.head_commit.id : github.sha); // like "ec26c3e57ca3a959ca5aad62de7213c562f8c821"
+    const commitId = isPullRequest ? payload.pull_request.head.sha : (payload.head_commit ? payload.head_commit.id : github.context.sha); // like "ec26c3e57ca3a959ca5aad62de7213c562f8c821"
     const branchName = isPullRequest ? payload.pull_request.head.ref : payload.ref.replace(/^refs\/heads\//, ''); // like "my/branch_name"
     console.log(`🎋 On branch '${branchName}', head commit ${commitId}`);
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -191,7 +191,7 @@ exports.createDeployment = async function(applicationName, fullRepositoryName, b
     const fullRepositoryName = payload.repository.full_name; // like "Codertocat/Hello-World"
 
     const isPullRequest = payload.pull_request !== undefined;
-    const commitId = isPullRequest ? payload.pull_request.head.sha : payload.head_commit.id; // like "ec26c3e57ca3a959ca5aad62de7213c562f8c821"
+    const commitId = isPullRequest ? payload.pull_request.head.sha : (payload.head_commit ? payload.head_commit.id : github.sha); // like "ec26c3e57ca3a959ca5aad62de7213c562f8c821"
     const branchName = isPullRequest ? payload.pull_request.head.ref : payload.ref.replace(/^refs\/heads\//, ''); // like "my/branch_name"
     console.log(`🎋 On branch '${branchName}', head commit ${commitId}`);
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@
     const fullRepositoryName = payload.repository.full_name; // like "Codertocat/Hello-World"
 
     const isPullRequest = payload.pull_request !== undefined;
-    const commitId = isPullRequest ? payload.pull_request.head.sha : payload.head_commit.id; // like "ec26c3e57ca3a959ca5aad62de7213c562f8c821"
+    const commitId = isPullRequest ? payload.pull_request.head.sha : (payload.head_commit ? payload.head_commit.id : github.sha); // like "ec26c3e57ca3a959ca5aad62de7213c562f8c821"
     const branchName = isPullRequest ? payload.pull_request.head.ref : payload.ref.replace(/^refs\/heads\//, ''); // like "my/branch_name"
     console.log(`🎋 On branch '${branchName}', head commit ${commitId}`);
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@
     const fullRepositoryName = payload.repository.full_name; // like "Codertocat/Hello-World"
 
     const isPullRequest = payload.pull_request !== undefined;
-    const commitId = isPullRequest ? payload.pull_request.head.sha : (payload.head_commit ? payload.head_commit.id : github.sha); // like "ec26c3e57ca3a959ca5aad62de7213c562f8c821"
+    const commitId = isPullRequest ? payload.pull_request.head.sha : (payload.head_commit ? payload.head_commit.id : github.context.sha); // like "ec26c3e57ca3a959ca5aad62de7213c562f8c821"
     const branchName = isPullRequest ? payload.pull_request.head.ref : payload.ref.replace(/^refs\/heads\//, ''); // like "my/branch_name"
     console.log(`🎋 On branch '${branchName}', head commit ${commitId}`);
 


### PR DESCRIPTION
After console logging github.context I found that `sha` lives on `github.context` not `github.context.payload` so if `head_commit` is not defined, we use `github.context.sha` instead. Thanks for considering this fix.

Fixes webfactory/create-aws-codedeploy-deployment#7