### PR TITLE
Add a switch to ignore the sequence check

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ This workaround should catch a good share of possible out-of-order deployments. 
 ### Input
 
 * `application`: The name of the CodeDeploy Application to work with. Defaults to the "short" repo name.
+* `skip-sequence-check`: When set to `true`, do not attempt to make sure deployments happen in order. Use this when the workflow count has been reset or changed to a lower value; possible cause is renaming the workflow file.
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,9 @@ description: 'An Action to deploy GitHub repos with AWS CodeDeploy'
 inputs:
     application:
         description: 'AWS CodeDeploy application name; defaults to short repository name'
+    skip-sequence-check:
+        description: 'When set, skip the check making sure no earlier workflow results are deployed'
+        default: false
 outputs:
     deploymentId:
         description: AWS CodeDeployment Deployment-ID of the deployment created

--- a/cli.js
+++ b/cli.js
@@ -79,7 +79,7 @@
 
     const action = require('./create-deployment');
     try {
-        await action.createDeployment(applicationName, fullRepositoryName, branchName, commitId, null, core);
+        await action.createDeployment(applicationName, fullRepositoryName, branchName, commitId, null, null, core);
     } catch (e) {
         console.log(`👉🏻 ${e.message}`);
         process.exit(1);

--- a/create-deployment.js
+++ b/create-deployment.js
@@ -23,7 +23,7 @@ function fetchBranchConfig(branchName) {
     process.exit();
 }
 
-exports.createDeployment = async function(applicationName, fullRepositoryName, branchName, commitId, runNumber, core) {
+exports.createDeployment = async function(applicationName, fullRepositoryName, branchName, commitId, runNumber, skipSequenceCheck, core) {
     const branchConfig = fetchBranchConfig(branchName);
     const safeBranchName = branchName.replace(/[^a-z0-9-/]+/gi, '-').replace(/\/+/, '--');
     const deploymentGroupName = branchConfig.deploymentGroupName ? branchConfig.deploymentGroupName.replace('$BRANCH', safeBranchName) : safeBranchName;
@@ -74,7 +74,7 @@ exports.createDeployment = async function(applicationName, fullRepositoryName, b
             return;
         }
 
-        if (runNumber) {
+        if (!skipSequenceCheck && runNumber) {
             var {deploymentGroupInfo: {lastAttemptedDeployment: {deploymentId: lastAttemptedDeploymentId} = {}}} = await codeDeploy.getDeploymentGroup({
                 applicationName: applicationName,
                 deploymentGroupName: deploymentGroupName,

--- a/index.js
+++ b/index.js
@@ -12,11 +12,14 @@
     const isPullRequest = payload.pull_request !== undefined;
     const commitId = isPullRequest ? payload.pull_request.head.sha : payload.head_commit.id; // like "ec26c3e57ca3a959ca5aad62de7213c562f8c821"
     const branchName = isPullRequest ? payload.pull_request.head.ref : payload.ref.replace(/^refs\/heads\//, ''); // like "my/branch_name"
+
+    const skipSequenceCheck = core.getBooleanInput('skip-sequence-check');
+
     console.log(`🎋 On branch '${branchName}', head commit ${commitId}`);
 
     const runNumber = process.env['github_run_number'] || process.env['GITHUB_RUN_NUMBER'];
 
     try {
-        action.createDeployment(applicationName, fullRepositoryName, branchName, commitId, runNumber, core);
+        action.createDeployment(applicationName, fullRepositoryName, branchName, commitId, runNumber, skipSequenceCheck, core);
     } catch (e) {}
 })();


### PR DESCRIPTION
Useful if, for example, the workflow file is renamed and GHA starts
counting workflow runs from #1 again.
