### PR TITLE
Fail gracefully with an error message when appspec.yml is missing

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -16,11 +16,20 @@ module.exports = JSON.parse("{\"name\":\"@octokit/rest\",\"version\":\"16.43.2\"
 "use strict";
 
 
-function fetchBranchConfig(branchName) {
+function fetchBranchConfig(branchName, core) {
     const fs = __webpack_require__(5747);
     const yaml = __webpack_require__(1917);
 
-    let fileContents = fs.readFileSync('./appspec.yml', 'utf8');
+    try {
+        let fileContents = fs.readFileSync('./appspec.yml', 'utf8');
+    } catch (e) {
+        if (e.code == 'ENOENT') {
+            core.setFailed('🙄 appspec.yml file not found. Hint: Did you run actions/checkout?');
+            process.exit();
+        } else {
+            throw e;
+        }
+    }
     let data = yaml.safeLoad(fileContents);
 
     for (var prop in data.branch_config) {
@@ -40,7 +49,7 @@ function fetchBranchConfig(branchName) {
 }
 
 exports.createDeployment = async function(applicationName, fullRepositoryName, branchName, commitId, runNumber, skipSequenceCheck, core) {
-    const branchConfig = fetchBranchConfig(branchName);
+    const branchConfig = fetchBranchConfig(branchName, core);
     const safeBranchName = branchName.replace(/[^a-z0-9-/]+/gi, '-').replace(/\/+/, '--');
     const deploymentGroupName = branchConfig.deploymentGroupName ? branchConfig.deploymentGroupName.replace('$BRANCH', safeBranchName) : safeBranchName;
     const deploymentGroupConfig = branchConfig.deploymentGroupConfig;


### PR DESCRIPTION
Fail gracefully when the `appspec.yml` file was not found. Might be a common mistake to forget running `actions/checkout` before this action here.

Closes #10.