### PR TITLE
Allow overriding the branch name used to look up configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ jobs:
                 with:
                     token: ${{ secrets.GITHUB_TOKEN }}
                     body: |
-                        @${{ github.actor }} this was deployed as [${{ steps.deploy.outputs.deploymentId }}](https://console.aws.amazon.com/codesuite/codedeploy/deployments/${{ steps.deploy.outputs.deploymentId }}?region=eu-central-1) to group `${{ steps.deploy.outputs.deploymentGroupName }}`.
+                        @${{ github.actor }} this was deployed as [${{ steps.deploy.outputs.deploymentId }}](https://console.aws.amazon.com/codesuite/codedeploy/deployments/${{ steps.deploy.outputs.deploymentId }}?region=eu-central-1) to group `${{ steps.deploy.outputs.deploymentGroupName }}`.
 ```
 
 First, this configures AWS Credentials in the GitHub Action runner. The [aws-actions/configure-aws-credentials](https://github.com/aws-actions/configure-aws-credentials) action is used for that, and credentials are kept in [GitHub Actions Secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets).
@@ -165,6 +165,7 @@ This workaround should catch a good share of possible out-of-order deployments. 
 
 * `application`: The name of the CodeDeploy Application to work with. Defaults to the "short" repo name.
 * `skip-sequence-check`: When set to `true`, do not attempt to make sure deployments happen in order. Use this when the workflow count has been reset or changed to a lower value; possible cause is renaming the workflow file.
+* `config-name`: Name used to look up the deployment config in the `branch_config` section of the `appspec.yml` file. Defaults to the current branch name. By using this override, you can force a particular config to be used regardless of the branch name. Or, you can run the action several times within the same job to create multiple (different) deployments from the same branch.
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,9 @@ inputs:
     skip-sequence-check:
         description: 'When set, skip the check making sure no earlier workflow results are deployed'
         default: false
+    config-name:
+        description: 'Override name to look up branch_config; default is to use the current branch name.'
+        default: ''
 outputs:
     deploymentId:
         description: AWS CodeDeployment Deployment-ID of the deployment created

--- a/cli.js
+++ b/cli.js
@@ -79,7 +79,7 @@
 
     const action = require('./create-deployment');
     try {
-        await action.createDeployment(applicationName, fullRepositoryName, branchName, commitId, null, null, core);
+        await action.createDeployment(applicationName, fullRepositoryName, branchName, branchName, commitId, null, null, core);
     } catch (e) {
         console.log(`👉🏻 ${e.message}`);
         process.exit(1);

--- a/create-deployment.js
+++ b/create-deployment.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function fetchBranchConfig(branchName, core) {
+function fetchBranchConfig(configLookupName, core) {
     const fs = require('fs');
     const yaml = require('js-yaml');
 
@@ -18,22 +18,22 @@ function fetchBranchConfig(branchName, core) {
 
     for (var prop in data.branch_config) {
         var regex = new RegExp('^' + prop + '$', 'i');
-        if (branchName.match(regex)) {
+        if (configLookupName.match(regex)) {
             if (data.branch_config[prop] == null) {
-                console.log(`🤷🏻‍♂️ Found an empty appspec.yml -> branch_config for '${branchName}' – skipping deployment`);
+                console.log(`🤷🏻‍♂️ Found an empty appspec.yml -> branch_config for '${configLookupName}' – skipping deployment`);
                 process.exit();
             }
-            console.log(`💡 Using appspec.yml -> branch_config '${prop}' for branch '${branchName}'`);
+            console.log(`💡 Using appspec.yml -> branch_config '${prop}' for '${configLookupName}'`);
             return data.branch_config[prop];
         }
     }
 
-    console.log(`❓ Found no matching appspec.yml -> branch_config for '${branchName}' – skipping deployment`);
+    console.log(`❓ Found no matching appspec.yml -> branch_config for '${configLookupName}' – skipping deployment`);
     process.exit();
 }
 
-exports.createDeployment = async function(applicationName, fullRepositoryName, branchName, commitId, runNumber, skipSequenceCheck, core) {
-    const branchConfig = fetchBranchConfig(branchName, core);
+exports.createDeployment = async function(applicationName, fullRepositoryName, branchName, configLookupName, commitId, runNumber, skipSequenceCheck, core) {
+    const branchConfig = fetchBranchConfig(configLookupName, core);
     const safeBranchName = branchName.replace(/[^a-z0-9-/]+/gi, '-').replace(/\/+/, '--');
     const deploymentGroupName = branchConfig.deploymentGroupName ? branchConfig.deploymentGroupName.replace('$BRANCH', safeBranchName) : safeBranchName;
     const deploymentGroupConfig = branchConfig.deploymentGroupConfig;

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@
     const isPullRequest = payload.pull_request !== undefined;
     const commitId = isPullRequest ? payload.pull_request.head.sha : (payload.head_commit ? payload.head_commit.id : github.context.sha); // like "ec26c3e57ca3a959ca5aad62de7213c562f8c821"
     const branchName = isPullRequest ? payload.pull_request.head.ref : payload.ref.replace(/^refs\/heads\//, ''); // like "my/branch_name"
+    const configLookupName = core.getInput('config-name') || branchName;
 
     const skipSequenceCheck = core.getBooleanInput('skip-sequence-check');
 
@@ -20,6 +21,6 @@
     const runNumber = process.env['github_run_number'] || process.env['GITHUB_RUN_NUMBER'];
 
     try {
-        action.createDeployment(applicationName, fullRepositoryName, branchName, commitId, runNumber, skipSequenceCheck, core);
+        action.createDeployment(applicationName, fullRepositoryName, branchName, configLookupName, commitId, runNumber, skipSequenceCheck, core);
     } catch (e) {}
 })();


### PR DESCRIPTION
This PR adds a new `config-name` action input value. It can be used to override the name used to look up the deployment configuration in the `branch_config` section of the appspec.yml file.

By default, the current branch name (`master`, or a PR branch) will be used to find a deployment config, by matching the regular expressions from the `branch_config` section in `appspec.yml`.

Overriding the value makes sense when running the action multiple times within the same job or workflow to create multiple deployments for a single push or PR.
