### PR TITLE
Add a `$PR_NUMBER` placeholder for deployment group names

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ The first entry makes the action skip the deployment (do nothing at all) when th
 
 Commits on the `master` branch are to be deployed in a Deployment Group called `production`. All other commits will create or update a Deployment Group named `$BRANCH.staging.acme.tld`, where `$BRANCH` will be replaced with a DNS-safe name derived from the current branch. Basically, a branch called `feat/123/new_gimmick` will use `feat-123-new-gimmick` for `$BRANCH`. Since the Deployment Group Name is available in the `$DEPLOYMENT_GROUP_NAME` environment variable inside your CodeDeploy Lifecycle Scripts, you can use that to create "staging" environments with a single, generic configuration statement.
 
+Similar to `$BRANCH`, for workflows triggered by Pull Requests, the string `$PR_NUMBER` will be replaced by the pull request number.  
+
 The `deploymentGroupConfig` and `deploymentConfig` keys in each of the two cases contain configuration that is passed as-is to the 
 [`CreateDeploymentGroup`](https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_CreateDeploymentGroup.html) or 
 [`UpdateDeploymentGroup`](https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_UpdateDeploymentGroup.html) API calls (for

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ outputs:
     deploymentGroupCreated:
         description: True, if a new deployment group was created; false if an already existing group was used.
 runs:
-    using: 'node12'
+    using: 'node16'
     main: 'dist/index.js'
 
 branding:

--- a/cli.js
+++ b/cli.js
@@ -79,7 +79,7 @@
 
     const action = require('./create-deployment');
     try {
-        await action.createDeployment(applicationName, fullRepositoryName, branchName, branchName, commitId, null, null, core);
+        await action.createDeployment(applicationName, fullRepositoryName, branchName, null, branchName, commitId, null, null, core);
     } catch (e) {
         console.log(`👉🏻 ${e.message}`);
         process.exit(1);

--- a/create-deployment.js
+++ b/create-deployment.js
@@ -32,10 +32,14 @@ function fetchBranchConfig(configLookupName, core) {
     process.exit();
 }
 
-exports.createDeployment = async function(applicationName, fullRepositoryName, branchName, configLookupName, commitId, runNumber, skipSequenceCheck, core) {
+exports.createDeployment = async function(applicationName, fullRepositoryName, branchName, pullRequestNumber, configLookupName, commitId, runNumber, skipSequenceCheck, core) {
     const branchConfig = fetchBranchConfig(configLookupName, core);
     const safeBranchName = branchName.replace(/[^a-z0-9-/]+/gi, '-').replace(/\/+/, '--');
-    const deploymentGroupName = branchConfig.deploymentGroupName ? branchConfig.deploymentGroupName.replace('$BRANCH', safeBranchName) : safeBranchName;
+
+    let deploymentGroupName = branchConfig.deploymentGroupName ?? safeBranchName;
+    deploymentGroupName.replace('$BRANCH', safeBranchName);
+    deploymentGroupName.replace('$PR_NUMBER', pullRequestNumber);
+
     const deploymentGroupConfig = branchConfig.deploymentGroupConfig;
     const deploymentConfig = branchConfig.deploymentConfig;
 

--- a/create-deployment.js
+++ b/create-deployment.js
@@ -35,11 +35,7 @@ function fetchBranchConfig(configLookupName, core) {
 exports.createDeployment = async function(applicationName, fullRepositoryName, branchName, pullRequestNumber, configLookupName, commitId, runNumber, skipSequenceCheck, core) {
     const branchConfig = fetchBranchConfig(configLookupName, core);
     const safeBranchName = branchName.replace(/[^a-z0-9-/]+/gi, '-').replace(/\/+/, '--');
-
-    let deploymentGroupName = branchConfig.deploymentGroupName ?? safeBranchName;
-    deploymentGroupName.replace('$BRANCH', safeBranchName);
-    deploymentGroupName.replace('$PR_NUMBER', pullRequestNumber);
-
+    const deploymentGroupName = (branchConfig.deploymentGroupName ?? safeBranchName).replace('$BRANCH', safeBranchName).replace('$PR_NUMBER', pullRequestNumber);
     const deploymentGroupConfig = branchConfig.deploymentGroupConfig;
     const deploymentConfig = branchConfig.deploymentConfig;
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -51,11 +51,7 @@ function fetchBranchConfig(configLookupName, core) {
 exports.createDeployment = async function(applicationName, fullRepositoryName, branchName, pullRequestNumber, configLookupName, commitId, runNumber, skipSequenceCheck, core) {
     const branchConfig = fetchBranchConfig(configLookupName, core);
     const safeBranchName = branchName.replace(/[^a-z0-9-/]+/gi, '-').replace(/\/+/, '--');
-
-    let deploymentGroupName = branchConfig.deploymentGroupName ?? safeBranchName;
-    deploymentGroupName.replace('$BRANCH', safeBranchName);
-    deploymentGroupName.replace('$PR_NUMBER', pullRequestNumber);
-
+    const deploymentGroupName = (branchConfig.deploymentGroupName ?? safeBranchName).replace('$BRANCH', safeBranchName).replace('$PR_NUMBER', pullRequestNumber);
     const deploymentGroupConfig = branchConfig.deploymentGroupConfig;
     const deploymentConfig = branchConfig.deploymentConfig;
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -48,10 +48,14 @@ function fetchBranchConfig(configLookupName, core) {
     process.exit();
 }
 
-exports.createDeployment = async function(applicationName, fullRepositoryName, branchName, configLookupName, commitId, runNumber, skipSequenceCheck, core) {
+exports.createDeployment = async function(applicationName, fullRepositoryName, branchName, pullRequestNumber, configLookupName, commitId, runNumber, skipSequenceCheck, core) {
     const branchConfig = fetchBranchConfig(configLookupName, core);
     const safeBranchName = branchName.replace(/[^a-z0-9-/]+/gi, '-').replace(/\/+/, '--');
-    const deploymentGroupName = branchConfig.deploymentGroupName ? branchConfig.deploymentGroupName.replace('$BRANCH', safeBranchName) : safeBranchName;
+
+    let deploymentGroupName = branchConfig.deploymentGroupName ?? safeBranchName;
+    deploymentGroupName.replace('$BRANCH', safeBranchName);
+    deploymentGroupName.replace('$PR_NUMBER', pullRequestNumber);
+
     const deploymentGroupConfig = branchConfig.deploymentGroupConfig;
     const deploymentConfig = branchConfig.deploymentConfig;
 
@@ -210,6 +214,7 @@ exports.createDeployment = async function(applicationName, fullRepositoryName, b
     const isPullRequest = payload.pull_request !== undefined;
     const commitId = isPullRequest ? payload.pull_request.head.sha : (payload.head_commit ? payload.head_commit.id : github.context.sha); // like "ec26c3e57ca3a959ca5aad62de7213c562f8c821"
     const branchName = isPullRequest ? payload.pull_request.head.ref : payload.ref.replace(/^refs\/heads\//, ''); // like "my/branch_name"
+    const pullRequestNumber = isPullRequest ? payload.pull_request.number : undefined;
     const configLookupName = core.getInput('config-name') || branchName;
 
     const skipSequenceCheck = core.getBooleanInput('skip-sequence-check');
@@ -219,7 +224,7 @@ exports.createDeployment = async function(applicationName, fullRepositoryName, b
     const runNumber = process.env['github_run_number'] || process.env['GITHUB_RUN_NUMBER'];
 
     try {
-        await action.createDeployment(applicationName, fullRepositoryName, branchName, configLookupName, commitId, runNumber, skipSequenceCheck, core);
+        await action.createDeployment(applicationName, fullRepositoryName, branchName, pullRequestNumber, configLookupName, commitId, runNumber, skipSequenceCheck, core);
     } catch (e) {
         console.log(`👉🏻 ${e.message}`);
         process.exit(1);

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@
     const isPullRequest = payload.pull_request !== undefined;
     const commitId = isPullRequest ? payload.pull_request.head.sha : (payload.head_commit ? payload.head_commit.id : github.context.sha); // like "ec26c3e57ca3a959ca5aad62de7213c562f8c821"
     const branchName = isPullRequest ? payload.pull_request.head.ref : payload.ref.replace(/^refs\/heads\//, ''); // like "my/branch_name"
+    const pullRequestNumber = isPullRequest ? payload.pull_request.number : undefined;
     const configLookupName = core.getInput('config-name') || branchName;
 
     const skipSequenceCheck = core.getBooleanInput('skip-sequence-check');
@@ -21,7 +22,7 @@
     const runNumber = process.env['github_run_number'] || process.env['GITHUB_RUN_NUMBER'];
 
     try {
-        await action.createDeployment(applicationName, fullRepositoryName, branchName, configLookupName, commitId, runNumber, skipSequenceCheck, core);
+        await action.createDeployment(applicationName, fullRepositoryName, branchName, pullRequestNumber, configLookupName, commitId, runNumber, skipSequenceCheck, core);
     } catch (e) {
         console.log(`👉🏻 ${e.message}`);
         process.exit(1);


### PR DESCRIPTION
This adds a second placeholder `$PR_NUMBER` (to the already existing `$BRANCH`) that can be used to derive deployment group names based on Pull Request IDs.
